### PR TITLE
py3(django): sentry.plugins import path changes

### DIFF
--- a/src/sentry_freight/plugin.py
+++ b/src/sentry_freight/plugin.py
@@ -10,7 +10,9 @@ import json
 
 import sentry_freight
 
-from sentry.plugins import ReleaseHook, ReleaseTrackingPlugin
+from sentry.plugins.bases import ReleaseTrackingPlugin
+from sentry.plugins.interfaces.releasehook import ReleaseHook
+
 
 DOC_HTML = """
 <p>Configure a Freight notification with the given webhook url.</p>


### PR DESCRIPTION
Missed a spot here.

Note that when merged into master, the sha (along with all other external plugins) needs to be updated in getsentry.
